### PR TITLE
Use exiftool to strip image EXIF data (preserving orientation)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -36,6 +36,15 @@ the following:
 * ``ffmpegthumbnailer`` executable in ``$PATH``
 
 
+EXIF Stripping
+--------------
+
+When ``STRIP_IMAGE_EXIF`` is enabled, all images uploaded will be
+processed through exiftool to strip all EXIF data except the orientation
+tag.
+Requires the ``exiftool`` script in ``$PATH``.
+
+
 INSTALL
 -------
 ::


### PR DESCRIPTION
Hi, I'm using `envs.sh` and was kind of surprised that it didn't strip potentially sensitive EXIF information from uploaded images (like GPS coordinates) especially since they are most likely going to be shared with other people.  Other image hosts like Imgur do this by default.

I tried doing this with just the Python exif module, but it was [producing corrupt JPEGs](https://gitlab.com/TNThieding/exif/-/issues/30), so this version shells out to the popular [Exiftool](https://exiftool.org/) to strip all non-orientation EXIF tags.

After stripping, the checksum is updated and re-checked against the existing files, which required moving some code around to re-use it so this diff looks larger than it would otherwise be.